### PR TITLE
Fix margin QR code

### DIFF
--- a/style.css
+++ b/style.css
@@ -25,10 +25,8 @@ body, html{
 }
 
 .QR{
-    width: 270px;
-    height: 290px;
-    padding: 5px;
-    margin-top: 10px;
+    width: 90%;
+    margin: 5% 5% 1rem 5%;
     box-sizing: border-box;
 }
 


### PR DESCRIPTION
Set width of image to 90% and margin on top and both sides to 5%.